### PR TITLE
limit maxOccurs to 1 in the response

### DIFF
--- a/api.wsdl
+++ b/api.wsdl
@@ -50,15 +50,15 @@
 	  <xs:element name="statusCode" type="xs:int"/>
 	  <xs:element minOccurs="0" maxOccurs="1" name="errorMessage" type="xs:string"/>
 	  <xs:choice>
-	    <xs:element minOccurs="0" maxOccurs="unbounded" name="returnedValuePipeline" 		type="tns:Pipeline"/>
-	    <xs:element minOccurs="0" maxOccurs="1" 		name="returnedValueExecution" 		type="tns:Execution"/>
-	    <xs:element minOccurs="0" maxOccurs="1" 		name="returnedValueGlobalProp" 		type="tns:GlobalProperties"/>
-	    <xs:element minOccurs="0" maxOccurs="unbounded" name="returnedValueStr" 			type="xs:string"/>
-	    <xs:element minOccurs="0" maxOccurs="unbounded" name="returnedValueListStrings" 			type="tns:ArrayOfStrings"/>
-	    <xs:element minOccurs="0" maxOccurs="unbounded" name="returnedValueListExecutions" 			type="tns:ArrayOfExecutions"/>
-	    <xs:element minOccurs="0" maxOccurs="unbounded" name="returnedValueListPipelines" 			type="tns:ArrayOfPipelines"/>
-	    <xs:element minOccurs="0" maxOccurs="1" 		name="returnedValueStatus" 			type="tns:ExecutionStatus"/>
-	    <xs:element minOccurs="0" maxOccurs="unbounded" name="returnedValuePairKey" 		type="tns:PipelineKeyBooleanValuePair"/>
+	    <xs:element minOccurs="0" maxOccurs="1" name="returnedValuePipeline" type="tns:Pipeline"/>
+	    <xs:element minOccurs="0" maxOccurs="1" name="returnedValueExecution" type="tns:Execution"/>
+	    <xs:element minOccurs="0" maxOccurs="1" name="returnedValueGlobalProp" type="tns:GlobalProperties"/>
+	    <xs:element minOccurs="0" maxOccurs="1" name="returnedValueStr" type="xs:string"/>
+	    <xs:element minOccurs="0" maxOccurs="1" name="returnedValueListStrings" type="tns:ArrayOfStrings"/>
+	    <xs:element minOccurs="0" maxOccurs="1" name="returnedValueListExecutions" type="tns:ArrayOfExecutions"/>
+	    <xs:element minOccurs="0" maxOccurs="1" name="returnedValueListPipelines" type="tns:ArrayOfPipelines"/>
+	    <xs:element minOccurs="0" maxOccurs="1" name="returnedValueStatus" type="tns:ExecutionStatus"/>
+	    <xs:element minOccurs="0" maxOccurs="unbounded" name="returnedValuePairKey" type="tns:PipelineKeyBooleanValuePair"/>
 	   </xs:choice>
 	</xs:sequence>
       </xs:complexType>


### PR DESCRIPTION
This modification is linked to the issue #17 

I don't know if it needs maxOccurs="1" for the returnedValuePairKey.

```
<xs:element minOccurs="0" maxOccurs="unbounded" name="returnedValuePairKey" type="tns:PipelineKeyBooleanValuePair"/>
``` 